### PR TITLE
Use >= instead of semver for peer dependencies

### DIFF
--- a/packages/eslint-config-cdk/package.json
+++ b/packages/eslint-config-cdk/package.json
@@ -12,11 +12,11 @@
     "index.js"
   ],
   "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": "^3.7.0",
-    "@typescript-eslint/parser": "^3.7.0",
+    "@typescript-eslint/eslint-plugin": ">=3.7.0",
+    "@typescript-eslint/parser": ">=3.7.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-import-resolver-typescript": "^2.2.0",
-    "eslint-plugin-cdk": "^0.2.1",
+    "eslint-plugin-cdk": ">=0.2.1",
     "eslint-plugin-import": "^2.21.2",
     "eslint-plugin-jest": "^23.18.0",
     "eslint-plugin-prettier": "^3.1.4",

--- a/packages/eslint-plugin-cdk/package.json
+++ b/packages/eslint-plugin-cdk/package.json
@@ -21,7 +21,7 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": "^3.9.0"
+    "@typescript-eslint/eslint-plugin": ">=3.9.0"
   },
   "dependencies": {
     "@typescript-eslint/experimental-utils": "^4.0.1",


### PR DESCRIPTION
Hi,

I'm using @typescript-eslint/eslint-plugin@4.0.1 and @typescript-eslint/parser@4.0.1 in my project and im getting those nasty warnings:

> npm WARN eslint-config-cdk@0.6.2 requires a peer of @typescript-eslint/eslint-plugin@^3.7.0 but none is installed. You must install peer dependencies yourself.
> npm WARN eslint-config-cdk@0.6.2 requires a peer of @typescript-eslint/parser@^3.7.0 but none is installed. You must install peer dependencies yourself.
> npm WARN eslint-config-cdk@0.6.2 requires a peer of eslint-plugin-cdk@^0.2.1 but none is installed. You must install peer dependencies yourself.
> npm WARN eslint-plugin-cdk@0.6.3 requires a peer of @typescript-eslint/eslint-plugin@^3.9.0 but none is installed. You must install peer dependencies yourself.

I guess @typescript-eslint/eslint-plugin is correlated with typescript version and typescript does not use semantic versioning! Their versions are marketing driven. So I think it would be safe to use >= for peer versions for those dependencies.

This will cover 3 out of 4 warnings. For eslint-plugin-cdk@^0.2.1 one I found in the internet that ^ operator behaves differently if 0 is upfront:

> ^1.2.3 := >=1.2.3-0 <2.0.0-0 "Compatible with 1.2.3". When using caret operators, anything from the specified version (including prerelease) will be supported up to, but not including, the next major version (or its prereleases). 1.5.1 will satisfy ^1.2.3, while 1.2.2 and 2.0.0-beta will not.
> ^0.1.3 := >=0.1.3-0 <0.2.0-0 "Compatible with 0.1.3". 0.x.x versions are special: the first non-zero component indicates potentially breaking changes, meaning the caret operator matches any version with the same first non-zero component starting at the specified version.
> ^0.0.2 := =0.0.2 "Only the version 0.0.2 is considered compatible"

So to add another guess I also think it should be safe for now to use >= for eslint-plugin-cdk peer dependency in eslint-config-cdk.

Please let me know what do you think and if this is safe. :beers: 