### PR TITLE
fix: --no-npmignore is no longer an option for jsii-pacmak

### DIFF
--- a/packages/cdkdx/src/commands/package-command.ts
+++ b/packages/cdkdx/src/commands/package-command.ts
@@ -25,7 +25,7 @@ export class PackageCommand extends BaseProjectCommand {
 
     if (this.projectInfo.isJsii) {
       const command = require.resolve('jsii-pacmak/bin/jsii-pacmak');
-      await execa(command, ['--outdir', outdir, '--no-npmignore']);
+      await execa(command, ['--outdir', outdir]);
     } else {
       const { stdout } = await execa('npm', ['pack']);
       const tarball = stdout.trim();


### PR DESCRIPTION
This PR attempts to address the issue as described in #30 by removing the --no-npmignore flag from the call to jsii-pacmak.